### PR TITLE
49 footer covers show more button

### DIFF
--- a/client/src/components/footer.jsx
+++ b/client/src/components/footer.jsx
@@ -12,7 +12,8 @@ const useStyles = makeStyles({
     width: '100%',
     height: '150px',
     backgroundColor: 'var(--clr-primary-color)',
-    position: 'absolute',
+    position: 'relative', // Relative position allows it to be placed right after content before it
+    marginTop: 'auto', // For search page when there are no results, it fills space
     '@media (max-width: 600px)': {
       maxHeight: '115px',
     },

--- a/client/src/components/footer.jsx
+++ b/client/src/components/footer.jsx
@@ -10,8 +10,12 @@ const useStyles = makeStyles({
   footer: {
     bottom: 0,
     width: '100%',
+    height: '150px',
     backgroundColor: 'var(--clr-primary-color)',
-    position: 'fixed',
+    position: 'absolute',
+    '@media (max-width: 600px)': {
+      maxHeight: '115px',
+    },
   },
 
   footerButton: {
@@ -33,7 +37,6 @@ const useStyles = makeStyles({
 
   footerButtonGrid: {
     maxWidth: '130px',
-
     '@media (max-width: 600px)': {
       maxWidth: '100px',
     },
@@ -42,7 +45,7 @@ const useStyles = makeStyles({
   footerGrid: {
     '@media (max-width: 320px)': {
       display: 'flex',
-      flexDirection: 'column',
+      flexDirection: 'row',
       alignItems: 'center',
     },
   },
@@ -72,11 +75,12 @@ function Footer() {
               About Us
             </Button>
           </Grid>
-          <Grid item className={classes.footerButtonGrid}>
+          {/* We can bring back contact us at a later stage */}
+          {/* <Grid item className={classes.footerButtonGrid}>
             <Button href="/contact-us" className={classes.footerButton}>
               Contact Us
             </Button>
-          </Grid>
+          </Grid> */}
         </Grid>
       </Container>
     </footer>

--- a/client/src/pages/aboutUsPage.jsx
+++ b/client/src/pages/aboutUsPage.jsx
@@ -1,15 +1,16 @@
 import React from "react";
-import "../stylings/home.css";
+import "../stylings/aboutUsPage.css"
 import Footer from "../components/footer";
 import AboutUs from '../components/aboutUs';
 
 const AboutUsPage = () => {
   return (
     <div id="aboutUsPage">
-      <AboutUs />
-      {/* Add footer back in later - will need to do some more work to 
-      have it properly formated */}
-      {/* <Footer /> */}
+      <div id="content-wrap">
+        <AboutUs/>
+        {/* <Footer/> */}
+      </div>
+      <Footer/>
     </div>
 
   );

--- a/client/src/pages/aboutUsPage.jsx
+++ b/client/src/pages/aboutUsPage.jsx
@@ -6,10 +6,7 @@ import AboutUs from '../components/aboutUs';
 const AboutUsPage = () => {
   return (
     <div id="aboutUsPage">
-      <div id="content-wrap">
-        <AboutUs/>
-        {/* <Footer/> */}
-      </div>
+      <AboutUs/>
       <Footer/>
     </div>
 

--- a/client/src/pages/home.jsx
+++ b/client/src/pages/home.jsx
@@ -5,7 +5,7 @@ import Search from "../components/search";
 
 const Home = () => {
   return (
-    <div id="home">
+    <div className="homepage">
       <Search />
       <Footer />
     </div>

--- a/client/src/stylings/aboutUsPage.css
+++ b/client/src/stylings/aboutUsPage.css
@@ -3,15 +3,7 @@
     min-height: 100vh;
   }
   
-  #content-wrap {
-    padding-bottom: 150px;    /* Footer height */
-  }
 
-  @media only screen and (max-width: 600px) {
-    #content-wrap {
-      padding-bottom: 115px;    /* Footer height */
-    }
-  }
 
   
 

--- a/client/src/stylings/aboutUsPage.css
+++ b/client/src/stylings/aboutUsPage.css
@@ -1,0 +1,18 @@
+#aboutUsPage {
+    position: relative;
+    min-height: 100vh;
+  }
+  
+  #content-wrap {
+    padding-bottom: 150px;    /* Footer height */
+  }
+
+  @media only screen and (max-width: 600px) {
+    #content-wrap {
+      padding-bottom: 115px;    /* Footer height */
+    }
+  }
+
+  
+
+  

--- a/client/src/stylings/footer.css
+++ b/client/src/stylings/footer.css
@@ -5,7 +5,7 @@
   margin-right: auto;
 }
 
-@media screen and (min-width: 600px) {
+@media screen and (min-width: 600.1px) {
   #logo {
     width: 210px;
   }

--- a/client/src/stylings/home.css
+++ b/client/src/stylings/home.css
@@ -1,3 +1,6 @@
 .homepage{
     display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    position: relative;
 }


### PR DESCRIPTION
Fixed footer functionality for search and about us page. Works for all screen sizes wider than 265px.
<img width="664" alt="Footer_1" src="https://github.com/relatable-course-visualization/Relatable/assets/116026428/95eba5ce-b698-4dfc-9dc8-3a6d1c6be69a">
<img width="255" alt="Footer_2" src="https://github.com/relatable-course-visualization/Relatable/assets/116026428/28e084ab-b074-4d08-a4b9-0d12febf3c4e">
<img width="374" alt="Footer_3" src="https://github.com/relatable-course-visualization/Relatable/assets/116026428/370d00db-a55c-4c91-b94f-5825098a5405">
<img width="587" alt="Footer_4" src="https://github.com/relatable-course-visualization/Relatable/assets/116026428/a64c8494-b660-4870-985d-8ce5add218f2">

